### PR TITLE
bugfix: stop drag/turn actions when leaving canvas

### DIFF
--- a/js/front-panel.js
+++ b/js/front-panel.js
@@ -396,6 +396,11 @@ class FrontPanel {
       }
     }, false)
 
+    this.canvas.addEventListener("mouseleave", (e) => {
+      this.dragging = false;
+      this.turning = false;
+    }, false)
+
     // Touch event handlers
 
     this.canvas.addEventListener("touchstart", (e) => {


### PR DESCRIPTION
Stop dragging actions when leaving the canvas. Otherwise the mouse becomes "stuck" and front-end behaves weird after re-entering canvas.