### PR TITLE
Add support for rotary switches

### DIFF
--- a/js/behringer-model-d.js
+++ b/js/behringer-model-d.js
@@ -62,7 +62,7 @@ const KNOBS = [
 ]
 const KNOB_TYPES = {
   large: {radius: 55, limit: 304},
-  medium: {radius: 45, limit: 160},
+  medium: {radius: 45, limit: 160, positions: 6},
   small: {radius: 30, limit: 300},
 }
 const TOGGLES = [

--- a/js/front-panel.js
+++ b/js/front-panel.js
@@ -312,8 +312,8 @@ class FrontPanel {
           this.turning = true;
           this.turnKnobIdx = knob.idx;
           this.turnPreviousY = pos.y;
-          this.turnOldValue = knob.value;
-          this.turnNewValue = knob.value;
+          this.turnOldValue = this.knobValues[knob.idx];
+          this.turnNewValue = this.knobValues[knob.idx];
           this.requestRedraw()
         }
       })
@@ -359,12 +359,19 @@ class FrontPanel {
       }
 
       if (this.turning) {
-        const knob = this.knobs[this.turnKnobIdx]
-        const knobType= this.knobTypes[knob.type]
-        this.knobValues[this.turnKnobIdx] += (this.turnPreviousY - pos.y) * 2
-        this.knobValues[this.turnKnobIdx] = Math.max(this.knobValues[this.turnKnobIdx], 0)
-        this.knobValues[this.turnKnobIdx] = Math.min(this.knobValues[this.turnKnobIdx], knobType.limit)
-        this.turnPreviousY = pos.y
+        const knob = this.knobs[this.turnKnobIdx];
+        const knobType = this.knobTypes[knob.type];
+        let value = this.knobValues[this.turnKnobIdx] + (this.turnPreviousY - pos.y) * 2;
+        this.turnNewValue += (this.turnPreviousY - pos.y) * 2;
+
+        if (knobType.positions !== undefined) {
+          const step = (knobType.limit / (knobType.positions - 1));
+          value = Math.round(this.turnNewValue / step) * step;
+        }
+        
+        this.knobValues[this.turnKnobIdx] = Math.max(value, 0);
+        this.knobValues[this.turnKnobIdx] = Math.min(this.knobValues[this.turnKnobIdx], knobType.limit);
+        this.turnPreviousY = pos.y;
         // console.log(this.knobValues[this.turnKnobIdx])
       }
       // e.preventDefault()


### PR DESCRIPTION
## Support for rotary switches


If the property `positions` is defined on a knob type, then this knob will be handled as a rotary switch. (positions should be an integer greater than 1)


https://github.com/virtuaCode/patch-library/blob/2747330ada7718c1e028cc4f37c93c3f26a903bc/js/behringer-model-d.js#L63-L67

